### PR TITLE
Add monitor websocket using command filter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,11 @@ new-symbol-mangling = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-valkey-module = "0.1.1"
+valkey-module = "0.1.9"
 serde = "1.0.207"
 serde_json = "1.0.124"
 rouille = "3.6.2"
+once_cell = "1.19.0"
 
 [lib]
 crate-type = ["cdylib"]


### PR DESCRIPTION
## Summary
- upgrade `valkey-module` dependency for command filter support
- add `/monitor` websocket endpoint
- broadcast commands via registered command filter
- track monitor clients with channels

## Testing
- `cargo build --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6872d5245a048323ad5da3c9c086531b